### PR TITLE
Bump dp cli 0.24

### DIFF
--- a/dataops/Dockerfile
+++ b/dataops/Dockerfile
@@ -20,7 +20,7 @@ RUN wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz && \
 ENV PATH=$PATH:$PWD/google-cloud-sdk/bin/:/usr/local/bin/
 
 FROM base as aws
-RUN apt-get install awscli
+RUN apt-get install awscli -y
 ENV PATH=$PATH:~/.local/bin
 COPY requirements-aws.txt ./
 RUN pip install -r requirements-aws.txt

--- a/dataops/Dockerfile
+++ b/dataops/Dockerfile
@@ -7,17 +7,15 @@ RUN apt-get update && \
 RUN mkdir /root/.ssh && \
     ssh-keyscan -t rsa gitlab.com >> ~/.ssh/known_hosts
 
-# Update python and install packages
-COPY requirements.txt ./
-RUN pip install --upgrade pip setuptools wheel --no-cache-dir \
-  -r requirements.txt
+# Update python
+RUN pip install --upgrade pip setuptools wheel --no-cache-dir
 
 FROM base as gcp
 COPY requirements-gcp.txt ./
 RUN pip install -r requirements-gcp.txt
 RUN wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz && \
     tar zxvf google-cloud-sdk.tar.gz && ./google-cloud-sdk/install.sh --usage-reporting=false --path-update=true && \
-    rm -rf google-cloud-sdk.tar.gz 
+    rm -rf google-cloud-sdk.tar.gz
 
 ENV PATH=$PATH:$PWD/google-cloud-sdk/bin/:/usr/local/bin/
 

--- a/dataops/Dockerfile
+++ b/dataops/Dockerfile
@@ -20,5 +20,7 @@ RUN wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.tar.gz && \
 ENV PATH=$PATH:$PWD/google-cloud-sdk/bin/:/usr/local/bin/
 
 FROM base as aws
+RUN apt-get install awscli
+ENV PATH=$PATH:~/.local/bin
 COPY requirements-aws.txt ./
 RUN pip install -r requirements-aws.txt

--- a/dataops/requirements-aws.txt
+++ b/dataops/requirements-aws.txt
@@ -1,2 +1,2 @@
 awscli==1.27.2
-data-pipelines-cli[docker,datahub,s3,git,looker,snowflake]==0.23.0
+data-pipelines-cli[docker,datahub,s3,git,looker,dbt-all]==0.24.0

--- a/dataops/requirements-aws.txt
+++ b/dataops/requirements-aws.txt
@@ -1,2 +1,2 @@
-awscli==1.27.2
+awscli==1.27.32
 data-pipelines-cli[docker,datahub,s3,git,looker,dbt-all]==0.24.0

--- a/dataops/requirements-aws.txt
+++ b/dataops/requirements-aws.txt
@@ -1,2 +1,1 @@
-awscli==1.27.32
 data-pipelines-cli[docker,datahub,s3,git,looker,dbt-all]==0.24.0

--- a/dataops/requirements-gcp.txt
+++ b/dataops/requirements-gcp.txt
@@ -1,1 +1,1 @@
-data-pipelines-cli[docker,datahub,gcs,git,looker,bigquery]==0.23.0
+data-pipelines-cli[docker,datahub,gcs,git,looker,dbt-all]==0.24.0

--- a/dataops/requirements.txt
+++ b/dataops/requirements.txt
@@ -1,1 +1,0 @@
-MarkupSafe==2.1.1

--- a/renovate.json
+++ b/renovate.json
@@ -43,11 +43,8 @@
                 "patch",
                 "digest"
             ],
-            "automerge": true,
+            "automerge": false,
             "automergeType": "branch"
         }
-    ],
-    "pip_requirements": {
-        "fileMatch": ["(^|/)([\\w-]*)requirements(^|/)([\\w-]*).(txt|pip)$"]
-      }
-  }
+    ]
+}


### PR DESCRIPTION
changes:
- removed awscli from `requirements-aws.txt` due to dependency conflict and moved to Dockerfile
- removed `requirements.txt` with MarkupSafe due to [dp cli](https://github.com/getindata/data-pipelines-cli/blob/524d68bb01a52728d3dbae2361811693afc5c2b6/setup.py#L9)
- bump dp cli and add `dbt-all` to dp cli args
- config in `renovatebot`